### PR TITLE
GIAS for SEND

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ gias/default-edubaseall-resource-file-name
 
 ### SEN Provision Type strings are parsed
 
-Note that the "SEN Provision Type" strings in CSV columns "SEN13(name)" to "SEN13 (name)" are parsed to:
+Note that the "SEN Provision Type" strings in CSV columns "SEN1 (name)" to "SEN13 (name)" are parsed to:
 
 - Return abbreviations only, not "<ABBREVIATION> - <NAME>" or "Not Applicable" as is in the edubaseall CSV.
 - Return abbreviations in upper case, which results in "SpLD" in the edubaseall CSV being returned as "SPLD" (which is the abbreviation used in the SEN2 return).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ gias/default-edubaseall-resource-file-name
 
 Note that the "SEN Provision Type" strings in CSV columns "SEN1 (name)" to "SEN13 (name)" are parsed to:
 
-- Return abbreviations only, not "``ABBREVIATION` - `NAME`" or "Not Applicable" as is in the edubaseall CSV.
+- Return abbreviations only, not "ABBREVIATION - NAME" or "Not Applicable" as is in the edubaseall CSV.
 - Return abbreviations in upper case, which results in "SpLD" in the edubaseall CSV being returned as "SPLD" (which is the abbreviation used in the SEN2 return).
 - Map "Not Applicable" (used in "SEN1 (name)" to missing. 
   (Note however that some schools have SEN provision type 1 entered as "Not Applicable" but still have some of types 2-13 filled in!?)

--- a/README.md
+++ b/README.md
@@ -6,15 +6,19 @@ See the [GIAS glossary](https://www.get-information-schools.service.gov.uk/gloss
 
 # Usage
 
+## Setup
+
 ``` clojure
 (require '[witan.gias :as gias])
-gias/default-edubaseall-resource-file-name ; Defalt `edubaseall` resource file of establishment data.
-gias/edubaseall-csv-columns                ; Map `edubaseall` CSV column names to (maps of) metadata.
-gias/edubaseall-columns                    ; Same as csv-columns but keyed by the (keyword) dataset column names.
-gias/edubaseall-csv-parser-fn              ; parser-fn map for reading `edubaseall` CSV file with CSV column names.
-gias/edubaseall-csv-key-fn                 ; Default key-fn to be applied to `edubaseall` CSV column names.
-gias/edubaseall-parser-fn                  ; Default parser-fn map for reading  `edubaseall` CSV file
-                                           ; after column names mapped using `edubaseall-csv-key-fn`.
+```
+
+##  Getting basic `edubaseall` datasets
+
+From "all establishments" `edubaseall` CSV files downloaded from [get-information-schools.service.gov.uk](https://www.get-information-schools.service.gov.uk/):
+
+```clojure
+;; Default `edubaseall` resource file of all establishment data.
+gias/default-edubaseall-resource-file-name
 
 ;; Read default `edubaseall` CSV file, with keyword column names.
 (gias/edubaseall->ds)
@@ -24,7 +28,95 @@ gias/edubaseall-parser-fn                  ; Default parser-fn map for reading  
 
 ;; Read an `edubaseall` file from specified path
 (gias/edubaseall->ds {::gias/edubaseall-file-path "/tmp/edubasealldata20230421.csv"})
+```
 
+### SEN Provision Type strings are parsed
+
+Note that the "SEN Provision Type" strings in CSV columns "SEN13(name)" to "SEN13 (name)" are parsed to:
+
+- Return abbreviations only, not "<ABBREVIATION> - <NAME>" or "Not Applicable" as is in the edubaseall CSV.
+- Return abbreviations in upper case, which results in "SpLD" in the edubaseall CSV being returned as "SPLD" (which is the abbreviation used in the SEN2 return).
+- Map "Not Applicable" (used in "SEN1 (name)" to missing. 
+  (Note however that some schools have SEN provision type 1 entered as "Not Applicable" but still have some of types 2-13 filled in!?)
+
+The mapping is via function `gias/parse-sen-provision-type-name`, implementing map:
+```clojure
+{"Not Applicable"                                   ::ds/missing ; Note missing
+ "SpLD - Specific Learning Difficulty"              "SPLD"       ; Note upper-case
+ "MLD - Moderate Learning Difficulty"               "MLD"
+ "SLD - Severe Learning Difficulty"                 "SLD"
+ "PMLD - Profound and Multiple Learning Difficulty" "PMLD"
+ "SEMH - Social, Emotional and Mental Health"       "SEMH"
+ "SLCN - Speech, language and Communication"        "SLCN"
+ "HI - Hearing Impairment"                          "HI"
+ "VI - Visual Impairment"                           "VI"
+ "MSI - Multi-Sensory Impairment"                   "MSI"
+ "PD - Physical Disability"                         "PD"
+ "ASD - Autistic Spectrum Disorder"                 "ASD"
+ "OTH - Other Difficulty/Disability"                "OTH"}
+```
+
+## GIAS for SEND
+
+Function `edubaseall-send->ds` reads SEND related columns from a GIAS `edubaseall` CSV export :
+
+- `:urn`
+- `:last-changed-date`
+- `:ukprn`
+- `:establishment-number`
+- `:establishment-name`
+- `:type-of-establishment-name`
+- `:establishment-type-group-name`
+- `:la-code`
+- `:la-name`
+- `:establishment-status-name`
+- `:open-date`
+- `:close-date`
+- `:phase-of-education-name`
+- `:statutory-low-age`
+- `:statutory-high-age`
+- `:further-education-type-name`
+- `:school-census-date`
+- `:school-capacity`
+- `:number-of-pupils`
+- `:places-pru`
+- `:senpru-name`
+- `:special-classes-name`
+- `:sen-stat`
+- `:sen-no-stat`
+- `:sen-unit-capacity`
+- `:sen-unit-on-roll`
+- `:resourced-provision-capacity`
+- `:resourced-provision-on-roll`
+
+…with additional derived columns:
+
+   - `:sen-provision-types-vec` - vector of (upper-case) SEN provision type abbreviations extracted from \"SEN1\"-\"SEN13\"
+   - `:resourced-provision?` - Boolean indicating if `:type-of-resourced-provision-name` indicates estab. has RP.
+   - `:sen-unit?` - Boolean indicating if `:type-of-resourced-provision-name` indicates estab. has a SENU.
+
+The column specification is in `gias/edubaseall-send-columns`.
+
+## Customised reads
+
+The `ns` provides `defs` from which the `:key-fn` & `:parser-fn`  used for the default reads above are derived:
+
+```clojure
+; Map `edubaseall` CSV column names to (maps of) metadata.
+gias/edubaseall-csv-columns
+; Same as csv-columns but keyed by the (keyword) dataset column names.
+gias/edubaseall-columns
+; parser-fn map for reading `edubaseall` CSV file with CSV column names.
+gias/edubaseall-csv-parser-fn
+; Default key-fn to be applied to `edubaseall` CSV column names.
+gias/edubaseall-csv-key-fn
+; Default parser-fn map for reading  `edubaseall` CSV file
+gias/edubaseall-parser-fn
+```
+
+The `edubaseall->ds` options map is merged into the TMD `->dataset` options map, allowing customisation of the CSV read, for example:
+
+```clojure
 ;; Read selected columns from default `edubaseall`, specified by CSV column name:
 (gias/edubaseall->ds {:column-allowlist ["URN" "EstablishmentName"]})
 
@@ -42,9 +134,9 @@ gias/edubaseall-parser-fn                  ; Default parser-fn map for reading  
   (gias/edubaseall->ds {:column-allowlist ["URN" "EstablishmentName"]
                         :key-fn           key-fn
                         :parser-fn        (update-keys gias/edubaseall-csv-parser-fn key-fn)}))
-
-
 ```
+
+`edubaseall-send->ds` supports the same options map as `edubaseall->ds` but as custom `:column-allowlist`, `:column-blocklist` and `:key-fn` are used to select and process the SEND related columns these options are ignored (over-ridden).
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -8,25 +8,25 @@ See the [GIAS glossary](https://www.get-information-schools.service.gov.uk/gloss
 
 ``` clojure
 (require '[witan.gias :as gias])
-gias/default-resource-file-name ; Defalt `edubaseall` resource file of establishment data.
-gias/csv-col-names              ; Sorted set of `edubaseall` CSV column names.
-gias/csv-col-name->label        ; Map `edubaseall` CSV column name to descriptive label.
-gias/csv-col-name->col-name     ; Map `edubaseall` CSV column name to (keyword) column name.
-gias/col-names                  ; Sorted set of (keyword) column names.
-gias/col-name->csv-col-name     ; Map (keyword) column name to `edubaseall` CSV column name.
-gias/col-name->label            ; Map (keyword) column name to descriptive label.
-gias/csv-parser-fn              ; parser-fn map for reading `edubaseall` CSV file with CSV column names.
-gias/key-fn                     ; Default key-fn to be applied to `edubaseall` CSV column names.
-gias/parser-fn                  ; parser-fn map for reading  `edubaseall` CSV file after column names mapped using `key-fn`.
+gias/default-edubaseall-resource-file-name ; Defalt `edubaseall` resource file of establishment data.
+gias/csv-col-names                         ; Sorted set of `edubaseall` CSV column names.
+gias/csv-col-name->label                   ; Map `edubaseall` CSV column name to descriptive label.
+gias/csv-col-name->col-name                ; Map `edubaseall` CSV column name to (keyword) column name.
+gias/col-names                             ; Sorted set of (keyword) column names.
+gias/col-name->csv-col-name                ; Map (keyword) column name to `edubaseall` CSV column name.
+gias/col-name->label                       ; Map (keyword) column name to descriptive label.
+gias/csv-parser-fn                         ; parser-fn map for reading `edubaseall` CSV file with CSV column names.
+gias/key-fn                                ; Default key-fn to be applied to `edubaseall` CSV column names.
+gias/parser-fn                             ; parser-fn map for reading  `edubaseall` CSV file after column names mapped using `key-fn`.
 
 ;; Read default `edubaseall` CSV file, with keyword column names.
 (gias/->ds)
 
 ;; Read a different `edubaseall` resource file
-(gias/->ds {::gias/resource-file-name "edubasealldata20230817.csv"})
+(gias/->ds {::gias/edubaseall-resource-file-name "edubasealldata20230817.csv"})
 
 ;; Read an `edubaseall` file from specified path
-(gias/->ds {::gias/file-path "/tmp/edubasealldata20230421.csv"})
+(gias/->ds {::gias/edubaseall-file-path "/tmp/edubasealldata20230421.csv"})
 
 ;; Read selected columns from default `edubaseall`, specified by column name:
 (gias/->ds {:column-allowlist (map gias/col-name->csv-col-name [:urn :establishment-name])})

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ gias/default-edubaseall-resource-file-name
 
 Note that the "SEN Provision Type" strings in CSV columns "SEN1 (name)" to "SEN13 (name)" are parsed to:
 
-- Return abbreviations only, not "<ABBREVIATION> - <NAME>" or "Not Applicable" as is in the edubaseall CSV.
+- Return abbreviations only, not "``<ABBREVIATION>` - `<NAME>`" or "Not Applicable" as is in the edubaseall CSV.
 - Return abbreviations in upper case, which results in "SpLD" in the edubaseall CSV being returned as "SPLD" (which is the abbreviation used in the SEN2 return).
 - Map "Not Applicable" (used in "SEN1 (name)" to missing. 
   (Note however that some schools have SEN provision type 1 entered as "Not Applicable" but still have some of types 2-13 filled in!?)

--- a/README.md
+++ b/README.md
@@ -9,42 +9,39 @@ See the [GIAS glossary](https://www.get-information-schools.service.gov.uk/gloss
 ``` clojure
 (require '[witan.gias :as gias])
 gias/default-edubaseall-resource-file-name ; Defalt `edubaseall` resource file of establishment data.
-gias/csv-col-names                         ; Sorted set of `edubaseall` CSV column names.
-gias/csv-col-name->label                   ; Map `edubaseall` CSV column name to descriptive label.
-gias/csv-col-name->col-name                ; Map `edubaseall` CSV column name to (keyword) column name.
-gias/col-names                             ; Sorted set of (keyword) column names.
-gias/col-name->csv-col-name                ; Map (keyword) column name to `edubaseall` CSV column name.
-gias/col-name->label                       ; Map (keyword) column name to descriptive label.
-gias/csv-parser-fn                         ; parser-fn map for reading `edubaseall` CSV file with CSV column names.
-gias/key-fn                                ; Default key-fn to be applied to `edubaseall` CSV column names.
-gias/parser-fn                             ; parser-fn map for reading  `edubaseall` CSV file after column names mapped using `key-fn`.
+gias/edubaseall-csv-columns                ; Map `edubaseall` CSV column names to (maps of) metadata.
+gias/edubaseall-columns                    ; Same as csv-columns but keyed by the (keyword) dataset column names.
+gias/edubaseall-csv-parser-fn              ; parser-fn map for reading `edubaseall` CSV file with CSV column names.
+gias/edubaseall-csv-key-fn                 ; Default key-fn to be applied to `edubaseall` CSV column names.
+gias/edubaseall-parser-fn                  ; Default parser-fn map for reading  `edubaseall` CSV file
+                                           ; after column names mapped using `edubaseall-csv-key-fn`.
 
 ;; Read default `edubaseall` CSV file, with keyword column names.
-(gias/->ds)
+(gias/edubaseall->ds)
 
 ;; Read a different `edubaseall` resource file
-(gias/->ds {::gias/edubaseall-resource-file-name "edubasealldata20230817.csv"})
+(gias/edubaseall->ds {::gias/edubaseall-resource-file-name "edubasealldata20230817.csv"})
 
 ;; Read an `edubaseall` file from specified path
-(gias/->ds {::gias/edubaseall-file-path "/tmp/edubasealldata20230421.csv"})
+(gias/edubaseall->ds {::gias/edubaseall-file-path "/tmp/edubasealldata20230421.csv"})
 
-;; Read selected columns from default `edubaseall`, specified by column name:
-(gias/->ds {:column-allowlist (map gias/col-name->csv-col-name [:urn :establishment-name])})
+;; Read selected columns from default `edubaseall`, specified by CSV column name:
+(gias/edubaseall->ds {:column-allowlist ["URN" "EstablishmentName"]})
 
 ;; Read "URN" as `:int32` (rather than `:string`):
-(gias/->ds {:column-allowlist (map gias/col-name->csv-col-name [:urn :establishment-name])
-            :parser-fn (assoc gias/parser-fn :urn :int32)})
+(gias/edubaseall->ds {:column-allowlist ["URN" "EstablishmentName"]
+                      :parser-fn (assoc gias/edubaseall-parser-fn :urn :int32)})
 
-;; Read seleced columns from default `edubaseall` CSV file with CSV colum names:
-(gias/->ds {:column-allowlist ["URN" "EstablishmentName"]
-            :key-fn           identity
-            :parser-fn        gias/csv-parser-fn})
+;; Read selected columns from default `edubaseall` CSV file with CSV colum names:
+(gias/edubaseall->ds {:column-allowlist ["URN" "EstablishmentName"]
+                      :key-fn           identity
+                      :parser-fn        gias/edubaseall-csv-parser-fn})
 
 ;; Read selected columns from default `edubaseall` with some custom column names:
-(let [key-fn #((merge gias/csv-col-name->col-name {"EstablishmentName" :gias-establishment-name}) % %)]
-  (gias/->ds {:column-allowlist ["URN" "EstablishmentName"]
-              :key-fn           key-fn
-              :parser-fn        (update-keys gias/csv-parser-fn key-fn)}))
+(let [key-fn #((merge (update-vals gias/csv-columns :col-name) {"EstablishmentName" :gias-establishment-name}) % %)]
+  (gias/edubaseall->ds {:column-allowlist ["URN" "EstablishmentName"]
+                        :key-fn           key-fn
+                        :parser-fn        (update-keys gias/edubaseall-csv-parser-fn key-fn)}))
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ gias/default-edubaseall-resource-file-name
 
 Note that the "SEN Provision Type" strings in CSV columns "SEN1 (name)" to "SEN13 (name)" are parsed to:
 
-- Return abbreviations only, not "``<ABBREVIATION>` - `<NAME>`" or "Not Applicable" as is in the edubaseall CSV.
+- Return abbreviations only, not "``ABBREVIATION` - `NAME`" or "Not Applicable" as is in the edubaseall CSV.
 - Return abbreviations in upper case, which results in "SpLD" in the edubaseall CSV being returned as "SPLD" (which is the abbreviation used in the SEN2 return).
 - Map "Not Applicable" (used in "SEN1 (name)" to missing. 
   (Note however that some schools have SEN provision type 1 entered as "Not Applicable" but still have some of types 2-13 filled in!?)

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths   ["src" "resources"]
  :deps    {org.clojure/clojure {:mvn/version "1.11.1"}}
  :aliases {:dev {:extra-deps {org.clojure/clojure        {:mvn/version "1.11.1"}
-                              techascent/tech.ml.dataset {:mvn/version "7.011"}
-                              scicloj/tablecloth         {:mvn/version "7.007"
+                              techascent/tech.ml.dataset {:mvn/version "7.012"}
+                              scicloj/tablecloth         {:mvn/version "7.012"
                                                           :exclusions  [techascent/tech.ml.dataset
                                                                         org.apache.poi/poi-ooxml-schemas
                                                                         org.apache.poi/poi

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths   ["src" "resources"]
  :deps    {org.clojure/clojure {:mvn/version "1.11.1"}}
  :aliases {:dev {:extra-deps {org.clojure/clojure        {:mvn/version "1.11.1"}
-                              techascent/tech.ml.dataset {:mvn/version "7.012"}
-                              scicloj/tablecloth         {:mvn/version "7.012"
+                              techascent/tech.ml.dataset {:mvn/version "7.014"}
+                              scicloj/tablecloth         {:mvn/version "7.014"
                                                           :exclusions  [techascent/tech.ml.dataset
                                                                         org.apache.poi/poi-ooxml-schemas
                                                                         org.apache.poi/poi

--- a/src/witan/gias.clj
+++ b/src/witan/gias.clj
@@ -281,7 +281,7 @@
           :col-name     :senpru-name
           :col-label    "PRU provision for SEN"}
          {:csv-col-name "EBD (name)"
-          :col-name     :ebd-name
+          :col-name     :pru-ebd-name
           :col-label    "PRU provision for EBD"}
          {:csv-col-name "PlacesPRU"
           :col-name     :places-pru
@@ -467,8 +467,8 @@
           :col-label    "FSM"}
          {:csv-col-name "AccreditationExpiryDate"
           :col-name     :accreditation-expiry-date
-          :col-label    "Accreditation expiry date"}]
-      $
+          :col-label    "Accreditation expiry date"
+          :parser-fn    [:packed-local-date parse-date]}] $
     ;; Add CSV file column numbers (for ordering)
     (map-indexed (fn [idx m] (assoc m :csv-col-num (inc idx))) $)
     ;; Extract into a map with `:csv-col-name`s as keys
@@ -517,8 +517,8 @@
 (defn edubaseall->ds
   "Read GIAS edubaseall \"all establishment\" data from CSV file into a dataset.
    Use optional `options` map to specify:
-   - CSV file to read: via ::edubaseall-file-path or ::edubaseall-resource-file-name (for files in resource folder).
-     [Defaults to ::edubaseall-resource-file-name `default-edubaseall-resource-file-name`.]
+   - CSV file to read: via `::edubaseall-file-path` or `::edubaseall-resource-file-name` (for files in resource folder).
+     [Defaults to `::edubaseall-resource-file-name` of `default-edubaseall-resource-file-name`.]
    - Additional or over-riding options for `->dataset`."
   ([] (edubaseall->ds {}))
   ([{::keys [edubaseall-resource-file-name edubaseall-file-path]
@@ -638,7 +638,7 @@
   ;;    |                 :teen-moth-places |                   TeenMothPlaces |                                   Teenage mothers capacity |             :int16 |       98 |      50323 |      0.000 |      45.00 |
   ;;    |                         :ccf-name |                       CCF (name) |                                      Child care facilities |            :string |    44688 |       5733 |            |            |
   ;;    |                      :senpru-name |                    SENPRU (name) |                                      PRU provision for SEN |            :string |    50410 |         11 |            |            |
-  ;;    |                         :ebd-name |                       EBD (name) |                                      PRU provision for EBD |            :string |    50414 |          7 |            |            |
+  ;;    |                     :pru-ebd-name |                       EBD (name) |                                      PRU provision for EBD |            :string |    50414 |          7 |            |            |
   ;;    |                       :places-pru |                        PlacesPRU |                                       Number of PRU places |             :int16 |      602 |      49819 |      0.000 |      300.0 |
   ;;    |                     :ft-prov-name |                    FTProv (name) |                              PRU offer full time provision |            :string |     1789 |      48632 |            |            |
   ;;    |                 :ed-by-other-name |                 EdByOther (name) |                       PRU offer tuition by anther provider |            :string |    44677 |       5744 |            |            |
@@ -698,7 +698,7 @@
   ;;    |                        :msoa-code |                      MSOA (code) |                                                MSOA (code) |            :string |    50421 |          0 |            |            |
   ;;    |                        :lsoa-code |                      LSOA (code) |                                                LSOA (code) |            :string |    50421 |          0 |            |            |
   ;;    |                              :fsm |                              FSM |                                                        FSM |             :int16 |    28851 |      21570 |      0.000 |      925.0 |
-  ;;    |        :accreditation-expiry-date |          AccreditationExpiryDate |                                  Accreditation expiry date |           :boolean |        0 |      50421 |            |            |
+  ;;    |        :accreditation-expiry-date |          AccreditationExpiryDate |                                  Accreditation expiry date | :packed-local-date |        0 |      50421 | 1970-01-01 | 1970-01-01 |
 
   )
 

--- a/src/witan/gias.clj
+++ b/src/witan/gias.clj
@@ -24,7 +24,22 @@
   [s]
   (java.time.LocalDate/parse s (java.time.format.DateTimeFormatter/ofPattern "dd-MM-uuuu")))
 
-
+(defn- parse-sen-provision-type-name
+  "Parse contents of \"SEN# (name)\" columns into standard (upper-case) EHCP primary need abbreviations"
+  [s]
+  (get {"Not Applicable"                                   ::ds/missing ; Note missing
+        "SpLD - Specific Learning Difficulty"              "SPLD"       ; Note upper-case
+        "MLD - Moderate Learning Difficulty"               "MLD"
+        "SLD - Severe Learning Difficulty"                 "SLD"
+        "PMLD - Profound and Multiple Learning Difficulty" "PMLD"
+        "SEMH - Social, Emotional and Mental Health"       "SEMH"
+        "SLCN - Speech, language and Communication"        "SLCN"
+        "HI - Hearing Impairment"                          "HI"
+        "VI - Visual Impairment"                           "VI"
+        "MSI - Multi-Sensory Impairment"                   "MSI"
+        "PD - Physical Disability"                         "PD"
+        "ASD - Autistic Spectrum Disorder"                 "ASD"
+        "OTH - Other Difficulty/Disability"                "OTH"} s s))
 
 
 ;;; # edubaseall
@@ -298,44 +313,57 @@
           :col-name     :section41-approved-name
           :col-label    "Section 41 approved"}
          {:csv-col-name "SEN1 (name)"
-          :col-name     :sen1-name
-          :col-label    "Type of SEN provision 1"}
+          :col-name     :sen-provision-type-1
+          :col-label    "Type of SEN provision 1"
+          :parser-fn    [:string parse-sen-provision-type-name]}
          {:csv-col-name "SEN2 (name)"
-          :col-name     :sen2-name
-          :col-label    "Type of SEN provision 2"}
+          :col-name     :sen-provision-type-2
+          :col-label    "Type of SEN provision 2"
+          :parser-fn    [:string parse-sen-provision-type-name]}
          {:csv-col-name "SEN3 (name)"
-          :col-name     :sen3-name
-          :col-label    "Type of SEN provision 3"}
+          :col-name     :sen-provision-type-3
+          :col-label    "Type of SEN provision 3"
+          :parser-fn    [:string parse-sen-provision-type-name]}
          {:csv-col-name "SEN4 (name)"
-          :col-name     :sen4-name
-          :col-label    "Type of SEN provision 4"}
+          :col-name     :sen-provision-type-4
+          :col-label    "Type of SEN provision 4"
+          :parser-fn    [:string parse-sen-provision-type-name]}
          {:csv-col-name "SEN5 (name)"
-          :col-name     :sen5-name
-          :col-label    "Type of SEN provision 5"}
+          :col-name     :sen-provision-type-5
+          :col-label    "Type of SEN provision 5"
+          :parser-fn    [:string parse-sen-provision-type-name]}
          {:csv-col-name "SEN6 (name)"
-          :col-name     :sen6-name
-          :col-label    "Type of SEN provision 6"}
+          :col-name     :sen-provision-type-6
+          :col-label    "Type of SEN provision 6"
+          :parser-fn    [:string parse-sen-provision-type-name]}
          {:csv-col-name "SEN7 (name)"
-          :col-name     :sen7-name
-          :col-label    "Type of SEN provision 7"}
+          :col-name     :sen-provision-type-7
+          :col-label    "Type of SEN provision 7"
+          :parser-fn    [:string parse-sen-provision-type-name]}
          {:csv-col-name "SEN8 (name)"
-          :col-name     :sen8-name
-          :col-label    "Type of SEN provision 8"}
+          :col-name     :sen-provision-type-8
+          :col-label    "Type of SEN provision 8"
+          :parser-fn    [:string parse-sen-provision-type-name]}
          {:csv-col-name "SEN9 (name)"
-          :col-name     :sen9-name
-          :col-label    "Type of SEN provision 9"}
+          :col-name     :sen-provision-type-9
+          :col-label    "Type of SEN provision 9"
+          :parser-fn    [:string parse-sen-provision-type-name]}
          {:csv-col-name "SEN10 (name)"
-          :col-name     :sen10-name
-          :col-label    "Type of SEN provision 10"}
+          :col-name     :sen-provision-type-10
+          :col-label    "Type of SEN provision 10"
+          :parser-fn    [:string parse-sen-provision-type-name]}
          {:csv-col-name "SEN11 (name)"
-          :col-name     :sen11-name
-          :col-label    "Type of SEN provision 11"}
+          :col-name     :sen-provision-type-11
+          :col-label    "Type of SEN provision 11"
+          :parser-fn    [:string parse-sen-provision-type-name]}
          {:csv-col-name "SEN12 (name)"
-          :col-name     :sen12-name
-          :col-label    "Type of SEN provision 12"}
+          :col-name     :sen-provision-type-12
+          :col-label    "Type of SEN provision 12"
+          :parser-fn    [:string parse-sen-provision-type-name]}
          {:csv-col-name "SEN13 (name)"
-          :col-name     :sen13-name
-          :col-label    "Type of SEN provision 13"}
+          :col-name     :sen-provision-type-13
+          :col-label    "Type of SEN provision 13"
+          :parser-fn    [:string parse-sen-provision-type-name]}
          {:csv-col-name "TypeOfResourcedProvision (name)"
           :col-name     :type-of-resourced-provision-name
           :col-label    "Type of resourced provision"}
@@ -644,19 +672,19 @@
   ;;    |                     :ft-prov-name |                    FTProv (name) |                              PRU offer full time provision |            :string |     1789 |      48632 |            |            |
   ;;    |                 :ed-by-other-name |                 EdByOther (name) |                       PRU offer tuition by anther provider |            :string |    44677 |       5744 |            |            |
   ;;    |          :section41-approved-name |         Section41Approved (name) |                                        Section 41 approved |            :string |    50421 |          0 |            |            |
-  ;;    |                        :sen1-name |                      SEN1 (name) |                                    Type of SEN provision 1 |            :string |     5599 |      44822 |            |            |
-  ;;    |                        :sen2-name |                      SEN2 (name) |                                    Type of SEN provision 2 |            :string |     1974 |      48447 |            |            |
-  ;;    |                        :sen3-name |                      SEN3 (name) |                                    Type of SEN provision 3 |            :string |     1177 |      49244 |            |            |
-  ;;    |                        :sen4-name |                      SEN4 (name) |                                    Type of SEN provision 4 |            :string |      819 |      49602 |            |            |
-  ;;    |                        :sen5-name |                      SEN5 (name) |                                    Type of SEN provision 5 |            :string |      594 |      49827 |            |            |
-  ;;    |                        :sen6-name |                      SEN6 (name) |                                    Type of SEN provision 6 |            :string |      516 |      49905 |            |            |
-  ;;    |                        :sen7-name |                      SEN7 (name) |                                    Type of SEN provision 7 |            :string |      460 |      49961 |            |            |
-  ;;    |                        :sen8-name |                      SEN8 (name) |                                    Type of SEN provision 8 |            :string |      387 |      50034 |            |            |
-  ;;    |                        :sen9-name |                      SEN9 (name) |                                    Type of SEN provision 9 |            :string |      304 |      50117 |            |            |
-  ;;    |                       :sen10-name |                     SEN10 (name) |                                   Type of SEN provision 10 |            :string |      207 |      50214 |            |            |
-  ;;    |                       :sen11-name |                     SEN11 (name) |                                   Type of SEN provision 11 |            :string |      142 |      50279 |            |            |
-  ;;    |                       :sen12-name |                     SEN12 (name) |                                   Type of SEN provision 12 |            :string |       98 |      50323 |            |            |
-  ;;    |                       :sen13-name |                     SEN13 (name) |                                   Type of SEN provision 13 |            :string |        5 |      50416 |            |            |
+  ;;    |             :sen-provision-type-1 |                      SEN1 (name) |                                    Type of SEN provision 1 |            :string |     5533 |      44888 |            |            |
+  ;;    |             :sen-provision-type-2 |                      SEN2 (name) |                                    Type of SEN provision 2 |            :string |     1974 |      48447 |            |            |
+  ;;    |             :sen-provision-type-3 |                      SEN3 (name) |                                    Type of SEN provision 3 |            :string |     1177 |      49244 |            |            |
+  ;;    |             :sen-provision-type-4 |                      SEN4 (name) |                                    Type of SEN provision 4 |            :string |      819 |      49602 |            |            |
+  ;;    |             :sen-provision-type-5 |                      SEN5 (name) |                                    Type of SEN provision 5 |            :string |      594 |      49827 |            |            |
+  ;;    |             :sen-provision-type-6 |                      SEN6 (name) |                                    Type of SEN provision 6 |            :string |      516 |      49905 |            |            |
+  ;;    |             :sen-provision-type-7 |                      SEN7 (name) |                                    Type of SEN provision 7 |            :string |      460 |      49961 |            |            |
+  ;;    |             :sen-provision-type-8 |                      SEN8 (name) |                                    Type of SEN provision 8 |            :string |      387 |      50034 |            |            |
+  ;;    |             :sen-provision-type-9 |                      SEN9 (name) |                                    Type of SEN provision 9 |            :string |      304 |      50117 |            |            |
+  ;;    |            :sen-provision-type-10 |                     SEN10 (name) |                                   Type of SEN provision 10 |            :string |      207 |      50214 |            |            |
+  ;;    |            :sen-provision-type-11 |                     SEN11 (name) |                                   Type of SEN provision 11 |            :string |      142 |      50279 |            |            |
+  ;;    |            :sen-provision-type-12 |                     SEN12 (name) |                                   Type of SEN provision 12 |            :string |       98 |      50323 |            |            |
+  ;;    |            :sen-provision-type-13 |                     SEN13 (name) |                                   Type of SEN provision 13 |            :string |        5 |      50416 |            |            |
   ;;    | :type-of-resourced-provision-name |  TypeOfResourcedProvision (name) |                                Type of resourced provision |            :string |     7033 |      43388 |            |            |
   ;;    |      :resourced-provision-on-roll |         ResourcedProvisionOnRoll |                         Resourced provision number on roll |             :int16 |     1900 |      48521 |      0.000 |       1872 |
   ;;    |     :resourced-provision-capacity |       ResourcedProvisionCapacity |                               Resourced provision capacity |             :int16 |     1933 |      48488 |      0.000 |       1250 |
@@ -788,9 +816,7 @@
        (though note that any `:column-allowlist`, `:column-blocklist` or `:key-fn` will be ignored)."
   ([] (edubaseall-send->ds {}))
   ([options]
-   (let [sen-provision-type-columns [:sen1-name  :sen2-name  :sen3-name  :sen4-name  :sen5-name
-                                     :sen6-name  :sen7-name  :sen8-name  :sen9-name  :sen10-name
-                                     :sen11-name :sen12-name :sen13-name]
+   (let [sen-provision-type-columns (map (comp keyword (partial format "sen-provision-type-%,d")) (range 1 14))
          columns-to-read            ((comp distinct concat)
                                      (keys edubaseall-send-columns)
                                      sen-provision-type-columns
@@ -812,23 +838,8 @@
                             "Resourced provision"              false
                             "Resourced provision and SEN unit" true
                             "SEN unit"                         true} % %))
-         ;; Pack SEN provision type abbreviations (upper-case) into a vector
-         (tc/map-columns :sen-provision-types-vec
-                         sen-provision-type-columns
-                         (fn [& args] (into []
-                                            (keep #({"Not Applicable"                                   nil
-                                                     "SpLD - Specific Learning Difficulty"              "SPLD" ; Note upper-case
-                                                     "MLD - Moderate Learning Difficulty"               "MLD"
-                                                     "SLD - Severe Learning Difficulty"                 "SLD"
-                                                     "PMLD - Profound and Multiple Learning Difficulty" "PMLD"
-                                                     "SEMH - Social, Emotional and Mental Health"       "SEMH"
-                                                     "SLCN - Speech, language and Communication"        "SLCN"
-                                                     "HI - Hearing Impairment"                          "HI"
-                                                     "VI - Visual Impairment"                           "VI"
-                                                     "MSI - Multi-Sensory Impairment"                   "MSI"
-                                                     "PD - Physical Disability"                         "PD"
-                                                     "ASD - Autistic Spectrum Disorder"                 "ASD"
-                                                     "OTH - Other Difficulty/Disability"                "OTH"} % %)) args)))
+         ;; Pack non-nil SEN provision type abbreviations into a vector
+         (tc/map-columns :sen-provision-types-vec sen-provision-type-columns #(filterv some? %&))
          ;; Arrange dataset
          (tc/select-columns (keys edubaseall-send-columns))
          (as-> $ (tc/set-dataset-name $ (str (tc/dataset-name $) " (SEND columns)")))))))
@@ -880,3 +891,4 @@
   ;;    |       :sen-provision-types-vec |                               |                              SEN Provision Types (derived) | :persistent-vector |    50421 |          0 |            |            |
 
   )
+

--- a/src/witan/gias.clj
+++ b/src/witan/gias.clj
@@ -150,8 +150,8 @@
           :col-name     :special-classes-name
           :col-label    "Special classes"}
          {:csv-col-name "CensusDate"
-          :col-name     :census-date
-          :col-label    "Census date"
+          :col-name     :school-census-date
+          :col-label    "School census date"
           :parser-fn    [:packed-local-date parse-date]}
          {:csv-col-name "NumberOfPupils"
           :col-name     :number-of-pupils
@@ -597,7 +597,7 @@
   ;;    |                  :school-capacity |                   SchoolCapacity |                                            School capacity |             :int16 |    38107 |      12314 |      1.000 |  1.000E+04 |
   ;;    |             :special-classes-code |            SpecialClasses (code) |                                     Special classes (code) |             :int16 |    50421 |          0 |      0.000 |      9.000 |
   ;;    |             :special-classes-name |            SpecialClasses (name) |                                            Special classes |            :string |    50301 |        120 |            |            |
-  ;;    |                      :census-date |                       CensusDate |                                                Census date | :packed-local-date |    29058 |      21363 | 2017-01-19 | 2023-01-19 |
+  ;;    |               :school-census-date |                       CensusDate |                                         School census date | :packed-local-date |    29058 |      21363 | 2017-01-19 | 2023-01-19 |
   ;;    |                 :number-of-pupils |                   NumberOfPupils |                                           Number of pupils |             :int16 |    29052 |      21369 |      0.000 |       3440 |
   ;;    |                   :number-of-boys |                     NumberOfBoys |                                             Number of boys |             :int16 |    29045 |      21376 |      0.000 |       1766 |
   ;;    |                  :number-of-girls |                    NumberOfGirls |                                            Number of girls |             :int16 |    29040 |      21381 |      0.000 |       1885 |

--- a/src/witan/gias.clj
+++ b/src/witan/gias.clj
@@ -297,43 +297,43 @@
           :col-label    "Section 41 approved"}
          {:csv-col-name "SEN1 (name)"
           :col-name     :sen1-name
-          :col-label    "SEN need 1"}
+          :col-label    "Type of SEN provision 1"}
          {:csv-col-name "SEN2 (name)"
           :col-name     :sen2-name
-          :col-label    "SEN need 2"}
+          :col-label    "Type of SEN provision 2"}
          {:csv-col-name "SEN3 (name)"
           :col-name     :sen3-name
-          :col-label    "SEN need 3"}
+          :col-label    "Type of SEN provision 3"}
          {:csv-col-name "SEN4 (name)"
           :col-name     :sen4-name
-          :col-label    "SEN need 4"}
+          :col-label    "Type of SEN provision 4"}
          {:csv-col-name "SEN5 (name)"
           :col-name     :sen5-name
-          :col-label    "SEN need 5"}
+          :col-label    "Type of SEN provision 5"}
          {:csv-col-name "SEN6 (name)"
           :col-name     :sen6-name
-          :col-label    "SEN need 6"}
+          :col-label    "Type of SEN provision 6"}
          {:csv-col-name "SEN7 (name)"
           :col-name     :sen7-name
-          :col-label    "SEN need 7"}
+          :col-label    "Type of SEN provision 7"}
          {:csv-col-name "SEN8 (name)"
           :col-name     :sen8-name
-          :col-label    "SEN need 8"}
+          :col-label    "Type of SEN provision 8"}
          {:csv-col-name "SEN9 (name)"
           :col-name     :sen9-name
-          :col-label    "SEN need 9"}
+          :col-label    "Type of SEN provision 9"}
          {:csv-col-name "SEN10 (name)"
           :col-name     :sen10-name
-          :col-label    "SEN need 10"}
+          :col-label    "Type of SEN provision 10"}
          {:csv-col-name "SEN11 (name)"
           :col-name     :sen11-name
-          :col-label    "SEN need 11"}
+          :col-label    "Type of SEN provision 11"}
          {:csv-col-name "SEN12 (name)"
           :col-name     :sen12-name
-          :col-label    "SEN need 12"}
+          :col-label    "Type of SEN provision 12"}
          {:csv-col-name "SEN13 (name)"
           :col-name     :sen13-name
-          :col-label    "SEN need 13"}
+          :col-label    "Type of SEN provision 13"}
          {:csv-col-name "TypeOfResourcedProvision (name)"
           :col-name     :type-of-resourced-provision-name
           :col-label    "Type of resourced provision"}
@@ -643,19 +643,19 @@
   ;;    |                     :ft-prov-name |                    FTProv (name) |                              PRU offer full time provision |            :string |     1789 |      48632 |            |            |
   ;;    |                 :ed-by-other-name |                 EdByOther (name) |                       PRU offer tuition by anther provider |            :string |    44677 |       5744 |            |            |
   ;;    |          :section41-approved-name |         Section41Approved (name) |                                        Section 41 approved |            :string |    50421 |          0 |            |            |
-  ;;    |                        :sen1-name |                      SEN1 (name) |                                                 SEN need 1 |            :string |     5599 |      44822 |            |            |
-  ;;    |                        :sen2-name |                      SEN2 (name) |                                                 SEN need 2 |            :string |     1974 |      48447 |            |            |
-  ;;    |                        :sen3-name |                      SEN3 (name) |                                                 SEN need 3 |            :string |     1177 |      49244 |            |            |
-  ;;    |                        :sen4-name |                      SEN4 (name) |                                                 SEN need 4 |            :string |      819 |      49602 |            |            |
-  ;;    |                        :sen5-name |                      SEN5 (name) |                                                 SEN need 5 |            :string |      594 |      49827 |            |            |
-  ;;    |                        :sen6-name |                      SEN6 (name) |                                                 SEN need 6 |            :string |      516 |      49905 |            |            |
-  ;;    |                        :sen7-name |                      SEN7 (name) |                                                 SEN need 7 |            :string |      460 |      49961 |            |            |
-  ;;    |                        :sen8-name |                      SEN8 (name) |                                                 SEN need 8 |            :string |      387 |      50034 |            |            |
-  ;;    |                        :sen9-name |                      SEN9 (name) |                                                 SEN need 9 |            :string |      304 |      50117 |            |            |
-  ;;    |                       :sen10-name |                     SEN10 (name) |                                                SEN need 10 |            :string |      207 |      50214 |            |            |
-  ;;    |                       :sen11-name |                     SEN11 (name) |                                                SEN need 11 |            :string |      142 |      50279 |            |            |
-  ;;    |                       :sen12-name |                     SEN12 (name) |                                                SEN need 12 |            :string |       98 |      50323 |            |            |
-  ;;    |                       :sen13-name |                     SEN13 (name) |                                                SEN need 13 |            :string |        5 |      50416 |            |            |
+  ;;    |                        :sen1-name |                      SEN1 (name) |                                    Type of SEN provision 1 |            :string |     5599 |      44822 |            |            |
+  ;;    |                        :sen2-name |                      SEN2 (name) |                                    Type of SEN provision 2 |            :string |     1974 |      48447 |            |            |
+  ;;    |                        :sen3-name |                      SEN3 (name) |                                    Type of SEN provision 3 |            :string |     1177 |      49244 |            |            |
+  ;;    |                        :sen4-name |                      SEN4 (name) |                                    Type of SEN provision 4 |            :string |      819 |      49602 |            |            |
+  ;;    |                        :sen5-name |                      SEN5 (name) |                                    Type of SEN provision 5 |            :string |      594 |      49827 |            |            |
+  ;;    |                        :sen6-name |                      SEN6 (name) |                                    Type of SEN provision 6 |            :string |      516 |      49905 |            |            |
+  ;;    |                        :sen7-name |                      SEN7 (name) |                                    Type of SEN provision 7 |            :string |      460 |      49961 |            |            |
+  ;;    |                        :sen8-name |                      SEN8 (name) |                                    Type of SEN provision 8 |            :string |      387 |      50034 |            |            |
+  ;;    |                        :sen9-name |                      SEN9 (name) |                                    Type of SEN provision 9 |            :string |      304 |      50117 |            |            |
+  ;;    |                       :sen10-name |                     SEN10 (name) |                                   Type of SEN provision 10 |            :string |      207 |      50214 |            |            |
+  ;;    |                       :sen11-name |                     SEN11 (name) |                                   Type of SEN provision 11 |            :string |      142 |      50279 |            |            |
+  ;;    |                       :sen12-name |                     SEN12 (name) |                                   Type of SEN provision 12 |            :string |       98 |      50323 |            |            |
+  ;;    |                       :sen13-name |                     SEN13 (name) |                                   Type of SEN provision 13 |            :string |        5 |      50416 |            |            |
   ;;    | :type-of-resourced-provision-name |  TypeOfResourcedProvision (name) |                                Type of resourced provision |            :string |     7033 |      43388 |            |            |
   ;;    |      :resourced-provision-on-roll |         ResourcedProvisionOnRoll |                         Resourced provision number on roll |             :int16 |     1900 |      48521 |      0.000 |       1872 |
   ;;    |     :resourced-provision-capacity |       ResourcedProvisionCapacity |                               Resourced provision capacity |             :int16 |     1933 |      48488 |      0.000 |       1250 |

--- a/src/witan/gias.clj
+++ b/src/witan/gias.clj
@@ -1,7 +1,6 @@
 (ns witan.gias
   "Read in \"Get Information About Schools\" (GIAS) all establishment data from CSV file downloaded from [get-information-schools.service.gov.uk/Downloads](https://www.get-information-schools.service.gov.uk/Downloads)"
   (:require [clojure.java.io :as io]
-            [clojure.set     :as set]
             [clojure.string  :as string]
             [tablecloth.api  :as tc]
             [tech.v3.dataset :as ds]))
@@ -10,7 +9,7 @@
 
 ;;; # Data files
 (def default-edubaseall-resource-file-name
-  "Name of resource file containing default establishment data"
+  "Name of default edubaseall resource file containing all establishment data"
   "edubasealldata20230918.csv")
 
 
@@ -21,447 +20,461 @@
   (compare [(get m k1) k1]
            [(get m k2) k2]))
 
+(defn parse-date
+  [s]
+  (java.time.LocalDate/parse s (java.time.format.DateTimeFormatter/ofPattern "dd-MM-uuuu")))
+
 
 
 ;;; # Column names, labels and types
-(def csv-col-name->order
-  "Map CSV column name to order."
-  (let [m (zipmap ["URN"
-                   "LA (code)"
-                   "LA (name)"
-                   "EstablishmentNumber"
-                   "EstablishmentName"
-                   "TypeOfEstablishment (code)"
-                   "TypeOfEstablishment (name)"
-                   "EstablishmentTypeGroup (code)"
-                   "EstablishmentTypeGroup (name)"
-                   "EstablishmentStatus (code)"
-                   "EstablishmentStatus (name)"
-                   "ReasonEstablishmentOpened (code)"
-                   "ReasonEstablishmentOpened (name)"
-                   "OpenDate"
-                   "ReasonEstablishmentClosed (code)"
-                   "ReasonEstablishmentClosed (name)"
-                   "CloseDate"
-                   "PhaseOfEducation (code)"
-                   "PhaseOfEducation (name)"
-                   "StatutoryLowAge"
-                   "StatutoryHighAge"
-                   "Boarders (code)"
-                   "Boarders (name)"
-                   "NurseryProvision (name)"
-                   "OfficialSixthForm (code)"
-                   "OfficialSixthForm (name)"
-                   "Gender (code)"
-                   "Gender (name)"
-                   "ReligiousCharacter (code)"
-                   "ReligiousCharacter (name)"
-                   "ReligiousEthos (name)"
-                   "Diocese (code)"
-                   "Diocese (name)"
-                   "AdmissionsPolicy (code)"
-                   "AdmissionsPolicy (name)"
-                   "SchoolCapacity"
-                   "SpecialClasses (code)"
-                   "SpecialClasses (name)"
-                   "CensusDate"
-                   "NumberOfPupils"
-                   "NumberOfBoys"
-                   "NumberOfGirls"
-                   "PercentageFSM"
-                   "TrustSchoolFlag (code)"
-                   "TrustSchoolFlag (name)"
-                   "Trusts (code)"
-                   "Trusts (name)"
-                   "SchoolSponsorFlag (name)"
-                   "SchoolSponsors (name)"
-                   "FederationFlag (name)"
-                   "Federations (code)"
-                   "Federations (name)"
-                   "UKPRN"
-                   "FEHEIdentifier"
-                   "FurtherEducationType (name)"
-                   "OfstedLastInsp"
-                   "OfstedSpecialMeasures (code)"
-                   "OfstedSpecialMeasures (name)"
-                   "LastChangedDate"
-                   "Street"
-                   "Locality"
-                   "Address3"
-                   "Town"
-                   "County (name)"
-                   "Postcode"
-                   "SchoolWebsite"
-                   "TelephoneNum"
-                   "HeadTitle (name)"
-                   "HeadFirstName"
-                   "HeadLastName"
-                   "HeadPreferredJobTitle"
-                   "BSOInspectorateName (name)"
-                   "InspectorateReport"
-                   "DateOfLastInspectionVisit"
-                   "NextInspectionVisit"
-                   "TeenMoth (name)"
-                   "TeenMothPlaces"
-                   "CCF (name)"
-                   "SENPRU (name)"
-                   "EBD (name)"
-                   "PlacesPRU"
-                   "FTProv (name)"
-                   "EdByOther (name)"
-                   "Section41Approved (name)"
-                   "SEN1 (name)"
-                   "SEN2 (name)"
-                   "SEN3 (name)"
-                   "SEN4 (name)"
-                   "SEN5 (name)"
-                   "SEN6 (name)"
-                   "SEN7 (name)"
-                   "SEN8 (name)"
-                   "SEN9 (name)"
-                   "SEN10 (name)"
-                   "SEN11 (name)"
-                   "SEN12 (name)"
-                   "SEN13 (name)"
-                   "TypeOfResourcedProvision (name)"
-                   "ResourcedProvisionOnRoll"
-                   "ResourcedProvisionCapacity"
-                   "SenUnitOnRoll"
-                   "SenUnitCapacity"
-                   "GOR (code)"
-                   "GOR (name)"
-                   "DistrictAdministrative (code)"
-                   "DistrictAdministrative (name)"
-                   "AdministrativeWard (code)"
-                   "AdministrativeWard (name)"
-                   "ParliamentaryConstituency (code)"
-                   "ParliamentaryConstituency (name)"
-                   "UrbanRural (code)"
-                   "UrbanRural (name)"
-                   "GSSLACode (name)"
-                   "Easting"
-                   "Northing"
-                   "MSOA (name)"
-                   "LSOA (name)"
-                   "InspectorateName (name)"
-                   "SENStat"
-                   "SENNoStat"
-                   "BoardingEstablishment (name)"
-                   "PropsName"
-                   "PreviousLA (code)"
-                   "PreviousLA (name)"
-                   "PreviousEstablishmentNumber"
-                   "OfstedRating (name)"
-                   "RSCRegion (name)"
-                   "Country (name)"
-                   "UPRN"
-                   "SiteName"
-                   "QABName (code)"
-                   "QABName (name)"
-                   "EstablishmentAccredited (code)"
-                   "EstablishmentAccredited (name)"
-                   "QABReport"
-                   "CHNumber"
-                   "MSOA (code)"
-                   "LSOA (code)"
-                   "FSM"
-                   "AccreditationExpiryDate"]
-                  (iterate inc 1))]
-    (into (sorted-map-by (partial compare-mapped-keys m)) m)))
-
-(def csv-col-names
-  (apply sorted-set-by
-         (partial compare-mapped-keys csv-col-name->order)
-         (keys csv-col-name->order)))
-
-(def csv-col-name->label
-  "Map CSV column name to label.
+(def edubaseall-csv-columns
+  "Map (ordered) edubaseall CSV column names to (maps of) metadata.
    Labels adapted from [www.get-information-schools.service.gov.uk/Guidance/EstablishmentBulkUpdate](https://www.get-information-schools.service.gov.uk/Guidance/EstablishmentBulkUpdate)."
-  (into (sorted-map-by (partial compare-mapped-keys csv-col-name->order)) 
-        {"URN"                              "URN"
-         "LA (code)"                        "LA (code)"
-         "LA (name)"                        "LA"
-         "EstablishmentNumber"              "Establishment Number"
-         "EstablishmentName"                "School / College Name"
-         "TypeOfEstablishment (code)"       "Establishment type (code)"
-         "TypeOfEstablishment (name)"       "Establishment type"
-         "EstablishmentTypeGroup (code)"    "Establishment type group (code)"
-         "EstablishmentTypeGroup (name)"    "Establishment type group"
-         "EstablishmentStatus (code)"       "Establishment status (code)"
-         "EstablishmentStatus (name)"       "Establishment status"
-         "ReasonEstablishmentOpened (code)" "Reason establishment opened (code)"
-         "ReasonEstablishmentOpened (name)" "Reason establishment opened"
-         "OpenDate"                         "Open date"
-         "ReasonEstablishmentClosed (code)" "Reason establishment closed (code)"
-         "ReasonEstablishmentClosed (name)" "Reason establishment closed"
-         "CloseDate"                        "Close date"
-         "PhaseOfEducation (code)"          "Phase of education (code)"
-         "PhaseOfEducation (name)"          "Phase of education"
-         "StatutoryLowAge"                  "Age range (low)"
-         "StatutoryHighAge"                 "Age range (high)"
-         "Boarders (code)"                  "Boarders (code)"
-         "Boarders (name)"                  "Boarders"
-         "NurseryProvision (name)"          "Nursery provision"
-         "OfficialSixthForm (code)"         "Official sixth form (code)"
-         "OfficialSixthForm (name)"         "Official sixth form"
-         "Gender (code)"                    "Gender of entry (code)"
-         "Gender (name)"                    "Gender of entry"
-         "ReligiousCharacter (code)"        "Religious character (code)"
-         "ReligiousCharacter (name)"        "Religious character"
-         "ReligiousEthos (name)"            "Religious ethos"
-         "Diocese (code)"                   "Diocese (code)"
-         "Diocese (name)"                   "Diocese"
-         "AdmissionsPolicy (code)"          "Admissons policy (code)"
-         "AdmissionsPolicy (name)"          "Admissons policy"
-         "SchoolCapacity"                   "School capacity"
-         "SpecialClasses (code)"            "Special classes (code)"
-         "SpecialClasses (name)"            "Special classes"
-         "CensusDate"                       "Census date"
-         "NumberOfPupils"                   "Number of pupils"
-         "NumberOfBoys"                     "Number of boys"
-         "NumberOfGirls"                    "Number of girls"
-         "PercentageFSM"                    "Percentage FSM"
-         "TrustSchoolFlag (code)"           "Trust school flag (code)"
-         "TrustSchoolFlag (name)"           "Trust school flag"
-         "Trusts (code)"                    "Academy trust or trust (code)"
-         "Trusts (name)"                    "Academy trust or trust"
-         "SchoolSponsorFlag (name)"         "School sponsor flag"
-         "SchoolSponsors (name)"            "Academy sponsor"
-         "FederationFlag (name)"            "Federation flag"
-         "Federations (code)"               "Federation (code)"
-         "Federations (name)"               "Federation"
-         "UKPRN"                            "UK provider reference number (UKPRN)"
-         "FEHEIdentifier"                   "FEHE identifier"
-         "FurtherEducationType (name)"      "Further education type"
-         "OfstedLastInsp"                   "Date of last OFSTED inspection"
-         "OfstedSpecialMeasures (code)"     "OFSTED special measures (code)"
-         "OfstedSpecialMeasures (name)"     "OFSTED special measures"
-         "LastChangedDate"                  "Last Changed Date"
-         "Street"                           "Street"
-         "Locality"                         "Locality"
-         "Address3"                         "Address 3"
-         "Town"                             "Town"
-         "County (name)"                    "County"
-         "Postcode"                         "Postcode"
-         "SchoolWebsite"                    "Website"
-         "TelephoneNum"                     "Telephone"
-         "HeadTitle (name)"                 "Headteacher/Principal title"
-         "HeadFirstName"                    "Headteacher/Principal first name"
-         "HeadLastName"                     "Headteacher/Principal last name"
-         "HeadPreferredJobTitle"            "Headteacher/Principal preferred job title"
-         "BSOInspectorateName (name)"       "BSO inspectorate name"
-         "InspectorateReport"               "Inspectorate report URL"
-         "DateOfLastInspectionVisit"        "Date of last inspection visit"
-         "NextInspectionVisit"              "Date of next inspection visit"
-         "TeenMoth (name)"                  "Teenage mothers"
-         "TeenMothPlaces"                   "Teenage mothers capacity"
-         "CCF (name)"                       "Child care facilities"
-         "SENPRU (name)"                    "PRU provision for SEN"
-         "EBD (name)"                       "PRU provision for EBD"
-         "PlacesPRU"                        "Number of PRU places"
-         "FTProv (name)"                    "PRU offer full time provision"
-         "EdByOther (name)"                 "PRU offer tuition by anther provider"
-         "Section41Approved (name)"         "Section 41 approved"
-         "SEN1 (name)"                      "SEN need 1"
-         "SEN2 (name)"                      "SEN need 2"
-         "SEN3 (name)"                      "SEN need 3"
-         "SEN4 (name)"                      "SEN need 4"
-         "SEN5 (name)"                      "SEN need 5"
-         "SEN6 (name)"                      "SEN need 6"
-         "SEN7 (name)"                      "SEN need 7"
-         "SEN8 (name)"                      "SEN need 8"
-         "SEN9 (name)"                      "SEN need 9"
-         "SEN10 (name)"                     "SEN need 10"
-         "SEN11 (name)"                     "SEN need 11"
-         "SEN12 (name)"                     "SEN need 12"
-         "SEN13 (name)"                     "SEN need 13"
-         "TypeOfResourcedProvision (name)"  "Type of resourced provision"
-         "ResourcedProvisionOnRoll"         "Resourced provision number on roll"
-         "ResourcedProvisionCapacity"       "Resourced provision capacity"
-         "SenUnitOnRoll"                    "SEN unit number on roll"
-         "SenUnitCapacity"                  "SEN unit capacity"
-         "GOR (code)"                       "GOR (code)"
-         "GOR (name)"                       "GOR"
-         "DistrictAdministrative (code)"    "District administrative (code)"
-         "DistrictAdministrative (name)"    "District administrative"
-         "AdministrativeWard (code)"        "Administrative ward (code)"
-         "AdministrativeWard (name)"        "Administrative ward"
-         "ParliamentaryConstituency (code)" "Parliamentary constituency (code)"
-         "ParliamentaryConstituency (name)" "Parliamentary constituency"
-         "UrbanRural (code)"                "Urban rural (code)"
-         "UrbanRural (name)"                "Urban rural"
-         "GSSLACode (name)"                 "GSSLA code"
-         "Easting"                          "Easting"
-         "Northing"                         "Northing"
-         "MSOA (name)"                      "MSOA"
-         "LSOA (name)"                      "LSOA"
-         "InspectorateName (name)"          "Inspectorate name"
-         "SENStat"                          "Number of special pupils under a SEN statement or EHCP"
-         "SENNoStat"                        "Number of special pupils not under a SEN statement or EHCP"
-         "BoardingEstablishment (name)"     "Boarding establishment"
-         "PropsName"                        "Proprietor's name"
-         "PreviousLA (code)"                "Previous local authority (code)"
-         "PreviousLA (name)"                "Previous local authority"
-         "PreviousEstablishmentNumber"      "Previous establishment number"
-         "OfstedRating (name)"              "OFSTED rating"
-         "RSCRegion (name)"                 "RSC region"
-         "Country (name)"                   "Country"
-         "UPRN"                             "UPRN"
-         "SiteName"                         "Site name"
-         "QABName (code)"                   "QAB name (code)"
-         "QABName (name)"                   "QAB name"
-         "EstablishmentAccredited (code)"   "Establishment accredited (code)"
-         "EstablishmentAccredited (name)"   "Establishment accredited"
-         "QABReport"                        "QAB report"
-         "CHNumber"                         "CH number"
-         "MSOA (code)"                      "MSOA (code)"
-         "LSOA (code)"                      "LSOA (code)"
-         "FSM"                              "FSM"
-         "AccreditationExpiryDate"          "Accreditation expiry date"}))
-
-(def csv-col-name->col-name
-  "Map CSV column name to name to be used in dataset."
-  (into (sorted-map-by (partial compare-mapped-keys csv-col-name->order)) 
-        {"URN"                              :urn
-         "LA (code)"                        :la-code
-         "LA (name)"                        :la-name
-         "EstablishmentNumber"              :establishment-number
-         "EstablishmentName"                :establishment-name
-         "TypeOfEstablishment (code)"       :type-of-establishment-code
-         "TypeOfEstablishment (name)"       :type-of-establishment-name
-         "EstablishmentTypeGroup (code)"    :establishment-type-group-code
-         "EstablishmentTypeGroup (name)"    :establishment-type-group-name
-         "EstablishmentStatus (code)"       :establishment-status-code
-         "EstablishmentStatus (name)"       :establishment-status-name
-         "ReasonEstablishmentOpened (code)" :reason-establishment-opened-code
-         "ReasonEstablishmentOpened (name)" :reason-establishment-opened-name
-         "OpenDate"                         :open-date
-         "ReasonEstablishmentClosed (code)" :reason-establishment-closed-code
-         "ReasonEstablishmentClosed (name)" :reason-establishment-closed-name
-         "CloseDate"                        :close-date
-         "PhaseOfEducation (code)"          :phase-of-education-code
-         "PhaseOfEducation (name)"          :phase-of-education-name
-         "StatutoryLowAge"                  :statutory-low-age
-         "StatutoryHighAge"                 :statutory-high-age
-         "Boarders (code)"                  :boarders-code
-         "Boarders (name)"                  :boarders-name
-         "NurseryProvision (name)"          :nursery-provision-name
-         "OfficialSixthForm (code)"         :official-sixth-form-code
-         "OfficialSixthForm (name)"         :official-sixth-form-name
-         "Gender (code)"                    :gender-code
-         "Gender (name)"                    :gender-name
-         "ReligiousCharacter (code)"        :religious-character-code
-         "ReligiousCharacter (name)"        :religious-character-name
-         "ReligiousEthos (name)"            :religious-ethos-name
-         "Diocese (code)"                   :diocese-code
-         "Diocese (name)"                   :diocese-name
-         "AdmissionsPolicy (code)"          :admissions-policy-code
-         "AdmissionsPolicy (name)"          :admissions-policy-name
-         "SchoolCapacity"                   :school-capacity
-         "SpecialClasses (code)"            :special-classes-code
-         "SpecialClasses (name)"            :special-classes-name
-         "CensusDate"                       :census-date
-         "NumberOfPupils"                   :number-of-pupils
-         "NumberOfBoys"                     :number-of-boys
-         "NumberOfGirls"                    :number-of-girls
-         "PercentageFSM"                    :percentage-fsm
-         "TrustSchoolFlag (code)"           :trust-school-flag-code
-         "TrustSchoolFlag (name)"           :trust-school-flag-name
-         "Trusts (code)"                    :trusts-code
-         "Trusts (name)"                    :trusts-name
-         "SchoolSponsorFlag (name)"         :school-sponsor-flag-name
-         "SchoolSponsors (name)"            :school-sponsors-name
-         "FederationFlag (name)"            :federation-flag-name
-         "Federations (code)"               :federations-code
-         "Federations (name)"               :federations-name
-         "UKPRN"                            :ukprn
-         "FEHEIdentifier"                   :fehe-identifier
-         "FurtherEducationType (name)"      :further-education-type-name
-         "OfstedLastInsp"                   :ofsted-last-insp
-         "OfstedSpecialMeasures (code)"     :ofsted-special-measures-code
-         "OfstedSpecialMeasures (name)"     :ofsted-special-measures-name
-         "LastChangedDate"                  :last-changed-date
-         "Street"                           :street
-         "Locality"                         :locality
-         "Address3"                         :address3
-         "Town"                             :town
-         "County (name)"                    :county-name
-         "Postcode"                         :postcode
-         "SchoolWebsite"                    :school-website
-         "TelephoneNum"                     :telephone-num
-         "HeadTitle (name)"                 :head-title-name
-         "HeadFirstName"                    :head-first-name
-         "HeadLastName"                     :head-last-name
-         "HeadPreferredJobTitle"            :head-preferred-job-title
-         "BSOInspectorateName (name)"       :bso-inspectorate-name-name
-         "InspectorateReport"               :inspectorate-report
-         "DateOfLastInspectionVisit"        :date-of-last-inspection-visit
-         "NextInspectionVisit"              :next-inspection-visit
-         "TeenMoth (name)"                  :teen-moth-name
-         "TeenMothPlaces"                   :teen-moth-places
-         "CCF (name)"                       :ccf-name
-         "SENPRU (name)"                    :senpru-name
-         "EBD (name)"                       :ebd-name
-         "PlacesPRU"                        :places-pru
-         "FTProv (name)"                    :ft-prov-name
-         "EdByOther (name)"                 :ed-by-other-name
-         "Section41Approved (name)"         :section41-approved-name
-         "SEN1 (name)"                      :sen1-name
-         "SEN2 (name)"                      :sen2-name
-         "SEN3 (name)"                      :sen3-name
-         "SEN4 (name)"                      :sen4-name
-         "SEN5 (name)"                      :sen5-name
-         "SEN6 (name)"                      :sen6-name
-         "SEN7 (name)"                      :sen7-name
-         "SEN8 (name)"                      :sen8-name
-         "SEN9 (name)"                      :sen9-name
-         "SEN10 (name)"                     :sen10-name
-         "SEN11 (name)"                     :sen11-name
-         "SEN12 (name)"                     :sen12-name
-         "SEN13 (name)"                     :sen13-name
-         "TypeOfResourcedProvision (name)"  :type-of-resourced-provision-name
-         "ResourcedProvisionOnRoll"         :resourced-provision-on-roll
-         "ResourcedProvisionCapacity"       :resourced-provision-capacity
-         "SenUnitOnRoll"                    :sen-unit-on-roll
-         "SenUnitCapacity"                  :sen-unit-capacity
-         "GOR (code)"                       :gor-code
-         "GOR (name)"                       :gor-name
-         "DistrictAdministrative (code)"    :district-administrative-code
-         "DistrictAdministrative (name)"    :district-administrative-name
-         "AdministrativeWard (code)"        :administrative-ward-code
-         "AdministrativeWard (name)"        :administrative-ward-name
-         "ParliamentaryConstituency (code)" :parliamentary-constituency-code
-         "ParliamentaryConstituency (name)" :parliamentary-constituency-name
-         "UrbanRural (code)"                :urban-rural-code
-         "UrbanRural (name)"                :urban-rural-name
-         "GSSLACode (name)"                 :gssla-code-name
-         "Easting"                          :easting
-         "Northing"                         :northing
-         "MSOA (name)"                      :msoa-name
-         "LSOA (name)"                      :lsoa-name
-         "InspectorateName (name)"          :inspectorate-name-name
-         "SENStat"                          :sen-stat
-         "SENNoStat"                        :sen-no-stat
-         "BoardingEstablishment (name)"     :boarding-establishment-name
-         "PropsName"                        :props-name
-         "PreviousLA (code)"                :previous-la-code
-         "PreviousLA (name)"                :previous-la-name
-         "PreviousEstablishmentNumber"      :previous-establishment-number
-         "OfstedRating (name)"              :ofsted-rating-name
-         "RSCRegion (name)"                 :rsc-region-name
-         "Country (name)"                   :country-name
-         "UPRN"                             :uprn
-         "SiteName"                         :site-name
-         "QABName (code)"                   :qab-name-code
-         "QABName (name)"                   :qab-name-name
-         "EstablishmentAccredited (code)"   :establishment-accredited-code
-         "EstablishmentAccredited (name)"   :establishment-accredited-name
-         "QABReport"                        :qab-report
-         "CHNumber"                         :ch-number
-         "MSOA (code)"                      :msoa-code
-         "LSOA (code)"                      :lsoa-code
-         "FSM"                              :fsm
-         "AccreditationExpiryDate"          :accreditation-expiry-date}))
+  (as-> [{:csv-col-name "URN"
+          :col-name     :urn
+          :col-label    "URN"
+          :parser-fn    :string}
+         {:csv-col-name "LA (code)"
+          :col-name     :la-code
+          :col-label    "LA (code)"
+          :parser-fn    :string}
+         {:csv-col-name "LA (name)"
+          :col-name     :la-name
+          :col-label    "LA"}
+         {:csv-col-name "EstablishmentNumber"
+          :col-name     :establishment-number
+          :col-label    "Establishment Number"
+          :parser-fn    :string}
+         {:csv-col-name "EstablishmentName"
+          :col-name     :establishment-name
+          :col-label    "School / College Name"}
+         {:csv-col-name "TypeOfEstablishment (code)"
+          :col-name     :type-of-establishment-code
+          :col-label    "Establishment type (code)"}
+         {:csv-col-name "TypeOfEstablishment (name)"
+          :col-name     :type-of-establishment-name
+          :col-label    "Establishment type"}
+         {:csv-col-name "EstablishmentTypeGroup (code)"
+          :col-name     :establishment-type-group-code
+          :col-label    "Establishment type group (code)"}
+         {:csv-col-name "EstablishmentTypeGroup (name)"
+          :col-name     :establishment-type-group-name
+          :col-label    "Establishment type group"}
+         {:csv-col-name "EstablishmentStatus (code)"
+          :col-name     :establishment-status-code
+          :col-label    "Establishment status (code)"}
+         {:csv-col-name "EstablishmentStatus (name)"
+          :col-name     :establishment-status-name
+          :col-label    "Establishment status"}
+         {:csv-col-name "ReasonEstablishmentOpened (code)"
+          :col-name     :reason-establishment-opened-code
+          :col-label    "Reason establishment opened (code)"}
+         {:csv-col-name "ReasonEstablishmentOpened (name)"
+          :col-name     :reason-establishment-opened-name
+          :col-label    "Reason establishment opened"}
+         {:csv-col-name "OpenDate"
+          :col-name     :open-date
+          :col-label    "Open date"
+          :parser-fn    [:packed-local-date parse-date]}
+         {:csv-col-name "ReasonEstablishmentClosed (code)"
+          :col-name     :reason-establishment-closed-code
+          :col-label    "Reason establishment closed (code)"}
+         {:csv-col-name "ReasonEstablishmentClosed (name)"
+          :col-name     :reason-establishment-closed-name
+          :col-label    "Reason establishment closed"}
+         {:csv-col-name "CloseDate"
+          :col-name     :close-date
+          :col-label    "Close date"
+          :parser-fn    [:packed-local-date parse-date]}
+         {:csv-col-name "PhaseOfEducation (code)"
+          :col-name     :phase-of-education-code
+          :col-label    "Phase of education (code)"}
+         {:csv-col-name "PhaseOfEducation (name)"
+          :col-name     :phase-of-education-name
+          :col-label    "Phase of education"}
+         {:csv-col-name "StatutoryLowAge"
+          :col-name     :statutory-low-age
+          :col-label    "Age range (low)"}
+         {:csv-col-name "StatutoryHighAge"
+          :col-name     :statutory-high-age
+          :col-label    "Age range (high)"}
+         {:csv-col-name "Boarders (code)"
+          :col-name     :boarders-code
+          :col-label    "Boarders (code)"}
+         {:csv-col-name "Boarders (name)"
+          :col-name     :boarders-name
+          :col-label    "Boarders"}
+         {:csv-col-name "NurseryProvision (name)"
+          :col-name     :nursery-provision-name
+          :col-label    "Nursery provision"}
+         {:csv-col-name "OfficialSixthForm (code)"
+          :col-name     :official-sixth-form-code
+          :col-label    "Official sixth form (code)"}
+         {:csv-col-name "OfficialSixthForm (name)"
+          :col-name     :official-sixth-form-name
+          :col-label    "Official sixth form"}
+         {:csv-col-name "Gender (code)"
+          :col-name     :gender-code
+          :col-label    "Gender of entry (code)"}
+         {:csv-col-name "Gender (name)"
+          :col-name     :gender-name
+          :col-label    "Gender of entry"}
+         {:csv-col-name "ReligiousCharacter (code)"
+          :col-name     :religious-character-code
+          :col-label    "Religious character (code)"}
+         {:csv-col-name "ReligiousCharacter (name)"
+          :col-name     :religious-character-name
+          :col-label    "Religious character"}
+         {:csv-col-name "ReligiousEthos (name)"
+          :col-name     :religious-ethos-name
+          :col-label    "Religious ethos"}
+         {:csv-col-name "Diocese (code)"
+          :col-name     :diocese-code
+          :col-label    "Diocese (code)"}
+         {:csv-col-name "Diocese (name)"
+          :col-name     :diocese-name
+          :col-label    "Diocese"}
+         {:csv-col-name "AdmissionsPolicy (code)"
+          :col-name     :admissions-policy-code
+          :col-label    "Admissons policy (code)"}
+         {:csv-col-name "AdmissionsPolicy (name)"
+          :col-name     :admissions-policy-name
+          :col-label    "Admissons policy"}
+         {:csv-col-name "SchoolCapacity"
+          :col-name     :school-capacity
+          :col-label    "School capacity"}
+         {:csv-col-name "SpecialClasses (code)"
+          :col-name     :special-classes-code
+          :col-label    "Special classes (code)"}
+         {:csv-col-name "SpecialClasses (name)"
+          :col-name     :special-classes-name
+          :col-label    "Special classes"}
+         {:csv-col-name "CensusDate"
+          :col-name     :census-date
+          :col-label    "Census date"
+          :parser-fn    [:packed-local-date parse-date]}
+         {:csv-col-name "NumberOfPupils"
+          :col-name     :number-of-pupils
+          :col-label    "Number of pupils"}
+         {:csv-col-name "NumberOfBoys"
+          :col-name     :number-of-boys
+          :col-label    "Number of boys"}
+         {:csv-col-name "NumberOfGirls"
+          :col-name     :number-of-girls
+          :col-label    "Number of girls"}
+         {:csv-col-name "PercentageFSM"
+          :col-name     :percentage-fsm
+          :col-label    "Percentage FSM"}
+         {:csv-col-name "TrustSchoolFlag (code)"
+          :col-name     :trust-school-flag-code
+          :col-label    "Trust school flag (code)"}
+         {:csv-col-name "TrustSchoolFlag (name)"
+          :col-name     :trust-school-flag-name
+          :col-label    "Trust school flag"}
+         {:csv-col-name "Trusts (code)"
+          :col-name     :trusts-code
+          :col-label    "Academy trust or trust (code)"}
+         {:csv-col-name "Trusts (name)"
+          :col-name     :trusts-name
+          :col-label    "Academy trust or trust"}
+         {:csv-col-name "SchoolSponsorFlag (name)"
+          :col-name     :school-sponsor-flag-name
+          :col-label    "School sponsor flag"}
+         {:csv-col-name "SchoolSponsors (name)"
+          :col-name     :school-sponsors-name
+          :col-label    "Academy sponsor"}
+         {:csv-col-name "FederationFlag (name)"
+          :col-name     :federation-flag-name
+          :col-label    "Federation flag"}
+         {:csv-col-name "Federations (code)"
+          :col-name     :federations-code
+          :col-label    "Federation (code)"}
+         {:csv-col-name "Federations (name)"
+          :col-name     :federations-name
+          :col-label    "Federation"}
+         {:csv-col-name "UKPRN"
+          :col-name     :ukprn
+          :col-label    "UK provider reference number (UKPRN)"
+          :parser-fn    :string}
+         {:csv-col-name "FEHEIdentifier"
+          :col-name     :fehe-identifier
+          :col-label    "FEHE identifier"
+          :parser-fn    :string}
+         {:csv-col-name "FurtherEducationType (name)"
+          :col-name     :further-education-type-name
+          :col-label    "Further education type"}
+         {:csv-col-name "OfstedLastInsp"
+          :col-name     :ofsted-last-insp
+          :col-label    "Date of last OFSTED inspection"
+          :parser-fn    [:packed-local-date parse-date]}
+         {:csv-col-name "OfstedSpecialMeasures (code)"
+          :col-name     :ofsted-special-measures-code
+          :col-label    "OFSTED special measures (code)"}
+         {:csv-col-name "OfstedSpecialMeasures (name)"
+          :col-name     :ofsted-special-measures-name
+          :col-label    "OFSTED special measures"}
+         {:csv-col-name "LastChangedDate"
+          :col-name     :last-changed-date
+          :col-label    "Last Changed Date"
+          :parser-fn    [:packed-local-date parse-date]}
+         {:csv-col-name "Street"
+          :col-name     :street
+          :col-label    "Street"}
+         {:csv-col-name "Locality"
+          :col-name     :locality
+          :col-label    "Locality"}
+         {:csv-col-name "Address3"
+          :col-name     :address3
+          :col-label    "Address 3"}
+         {:csv-col-name "Town"
+          :col-name     :town
+          :col-label    "Town"}
+         {:csv-col-name "County (name)"
+          :col-name     :county-name
+          :col-label    "County"}
+         {:csv-col-name "Postcode"
+          :col-name     :postcode
+          :col-label    "Postcode"}
+         {:csv-col-name "SchoolWebsite"
+          :col-name     :school-website
+          :col-label    "Website"}
+         {:csv-col-name "TelephoneNum"
+          :col-name     :telephone-num
+          :col-label    "Telephone"
+          :parser-fn    :string}
+         {:csv-col-name "HeadTitle (name)"
+          :col-name     :head-title-name
+          :col-label    "Headteacher/Principal title"}
+         {:csv-col-name "HeadFirstName"
+          :col-name     :head-first-name
+          :col-label    "Headteacher/Principal first name"}
+         {:csv-col-name "HeadLastName"
+          :col-name     :head-last-name
+          :col-label    "Headteacher/Principal last name"}
+         {:csv-col-name "HeadPreferredJobTitle"
+          :col-name     :head-preferred-job-title
+          :col-label    "Headteacher/Principal preferred job title"}
+         {:csv-col-name "BSOInspectorateName (name)"
+          :col-name     :bso-inspectorate-name-name
+          :col-label    "BSO inspectorate name"}
+         {:csv-col-name "InspectorateReport"
+          :col-name     :inspectorate-report
+          :col-label    "Inspectorate report URL"}
+         {:csv-col-name "DateOfLastInspectionVisit"
+          :col-name     :date-of-last-inspection-visit
+          :col-label    "Date of last inspection visit"
+          :parser-fn    [:packed-local-date parse-date]}
+         {:csv-col-name "NextInspectionVisit"
+          :col-name     :next-inspection-visit
+          :col-label    "Date of next inspection visit"
+          :parser-fn    [:packed-local-date parse-date]}
+         {:csv-col-name "TeenMoth (name)"
+          :col-name     :teen-moth-name
+          :col-label    "Teenage mothers"}
+         {:csv-col-name "TeenMothPlaces"
+          :col-name     :teen-moth-places
+          :col-label    "Teenage mothers capacity"}
+         {:csv-col-name "CCF (name)"
+          :col-name     :ccf-name
+          :col-label    "Child care facilities"}
+         {:csv-col-name "SENPRU (name)"
+          :col-name     :senpru-name
+          :col-label    "PRU provision for SEN"}
+         {:csv-col-name "EBD (name)"
+          :col-name     :ebd-name
+          :col-label    "PRU provision for EBD"}
+         {:csv-col-name "PlacesPRU"
+          :col-name     :places-pru
+          :col-label    "Number of PRU places"}
+         {:csv-col-name "FTProv (name)"
+          :col-name     :ft-prov-name
+          :col-label    "PRU offer full time provision"}
+         {:csv-col-name "EdByOther (name)"
+          :col-name     :ed-by-other-name
+          :col-label    "PRU offer tuition by anther provider"}
+         {:csv-col-name "Section41Approved (name)"
+          :col-name     :section41-approved-name
+          :col-label    "Section 41 approved"}
+         {:csv-col-name "SEN1 (name)"
+          :col-name     :sen1-name
+          :col-label    "SEN need 1"}
+         {:csv-col-name "SEN2 (name)"
+          :col-name     :sen2-name
+          :col-label    "SEN need 2"}
+         {:csv-col-name "SEN3 (name)"
+          :col-name     :sen3-name
+          :col-label    "SEN need 3"}
+         {:csv-col-name "SEN4 (name)"
+          :col-name     :sen4-name
+          :col-label    "SEN need 4"}
+         {:csv-col-name "SEN5 (name)"
+          :col-name     :sen5-name
+          :col-label    "SEN need 5"}
+         {:csv-col-name "SEN6 (name)"
+          :col-name     :sen6-name
+          :col-label    "SEN need 6"}
+         {:csv-col-name "SEN7 (name)"
+          :col-name     :sen7-name
+          :col-label    "SEN need 7"}
+         {:csv-col-name "SEN8 (name)"
+          :col-name     :sen8-name
+          :col-label    "SEN need 8"}
+         {:csv-col-name "SEN9 (name)"
+          :col-name     :sen9-name
+          :col-label    "SEN need 9"}
+         {:csv-col-name "SEN10 (name)"
+          :col-name     :sen10-name
+          :col-label    "SEN need 10"}
+         {:csv-col-name "SEN11 (name)"
+          :col-name     :sen11-name
+          :col-label    "SEN need 11"}
+         {:csv-col-name "SEN12 (name)"
+          :col-name     :sen12-name
+          :col-label    "SEN need 12"}
+         {:csv-col-name "SEN13 (name)"
+          :col-name     :sen13-name
+          :col-label    "SEN need 13"}
+         {:csv-col-name "TypeOfResourcedProvision (name)"
+          :col-name     :type-of-resourced-provision-name
+          :col-label    "Type of resourced provision"}
+         {:csv-col-name "ResourcedProvisionOnRoll"
+          :col-name     :resourced-provision-on-roll
+          :col-label    "Resourced provision number on roll"}
+         {:csv-col-name "ResourcedProvisionCapacity"
+          :col-name     :resourced-provision-capacity
+          :col-label    "Resourced provision capacity"}
+         {:csv-col-name "SenUnitOnRoll"
+          :col-name     :sen-unit-on-roll
+          :col-label    "SEN unit number on roll"}
+         {:csv-col-name "SenUnitCapacity"
+          :col-name     :sen-unit-capacity
+          :col-label    "SEN unit capacity"}
+         {:csv-col-name "GOR (code)"
+          :col-name     :gor-code
+          :col-label    "GOR (code)"}
+         {:csv-col-name "GOR (name)"
+          :col-name     :gor-name
+          :col-label    "GOR"}
+         {:csv-col-name "DistrictAdministrative (code)"
+          :col-name     :district-administrative-code
+          :col-label    "District administrative (code)"}
+         {:csv-col-name "DistrictAdministrative (name)"
+          :col-name     :district-administrative-name
+          :col-label    "District administrative"}
+         {:csv-col-name "AdministrativeWard (code)"
+          :col-name     :administrative-ward-code
+          :col-label    "Administrative ward (code)"}
+         {:csv-col-name "AdministrativeWard (name)"
+          :col-name     :administrative-ward-name
+          :col-label    "Administrative ward"}
+         {:csv-col-name "ParliamentaryConstituency (code)"
+          :col-name     :parliamentary-constituency-code
+          :col-label    "Parliamentary constituency (code)"}
+         {:csv-col-name "ParliamentaryConstituency (name)"
+          :col-name     :parliamentary-constituency-name
+          :col-label    "Parliamentary constituency"}
+         {:csv-col-name "UrbanRural (code)"
+          :col-name     :urban-rural-code
+          :col-label    "Urban rural (code)"}
+         {:csv-col-name "UrbanRural (name)"
+          :col-name     :urban-rural-name
+          :col-label    "Urban rural"}
+         {:csv-col-name "GSSLACode (name)"
+          :col-name     :gssla-code-name
+          :col-label    "GSSLA code"}
+         {:csv-col-name "Easting"
+          :col-name     :easting
+          :col-label    "Easting"}
+         {:csv-col-name "Northing"
+          :col-name     :northing
+          :col-label    "Northing"}
+         {:csv-col-name "MSOA (name)"
+          :col-name     :msoa-name
+          :col-label    "MSOA"}
+         {:csv-col-name "LSOA (name)"
+          :col-name     :lsoa-name
+          :col-label    "LSOA"}
+         {:csv-col-name "InspectorateName (name)"
+          :col-name     :inspectorate-name-name
+          :col-label    "Inspectorate name"}
+         {:csv-col-name "SENStat"
+          :col-name     :sen-stat
+          :col-label    "Number of special pupils under a SEN statement or EHCP"}
+         {:csv-col-name "SENNoStat"
+          :col-name     :sen-no-stat
+          :col-label    "Number of special pupils not under a SEN statement or EHCP"}
+         {:csv-col-name "BoardingEstablishment (name)"
+          :col-name     :boarding-establishment-name
+          :col-label    "Boarding establishment"}
+         {:csv-col-name "PropsName"
+          :col-name     :props-name
+          :col-label    "Proprietor's name"}
+         {:csv-col-name "PreviousLA (code)"
+          :col-name     :previous-la-code
+          :col-label    "Previous local authority (code)"
+          :parser-fn    :string}
+         {:csv-col-name "PreviousLA (name)"
+          :col-name     :previous-la-name
+          :col-label    "Previous local authority"}
+         {:csv-col-name "PreviousEstablishmentNumber"
+          :col-name     :previous-establishment-number
+          :col-label    "Previous establishment number"
+          :parser-fn    :string}
+         {:csv-col-name "OfstedRating (name)"
+          :col-name     :ofsted-rating-name
+          :col-label    "OFSTED rating"}
+         {:csv-col-name "RSCRegion (name)"
+          :col-name     :rsc-region-name
+          :col-label    "RSC region"}
+         {:csv-col-name "Country (name)"
+          :col-name     :country-name
+          :col-label    "Country"}
+         {:csv-col-name "UPRN"
+          :col-name     :uprn
+          :col-label    "UPRN"
+          :parser-fn    :string}
+         {:csv-col-name "SiteName"
+          :col-name     :site-name
+          :col-label    "Site name"}
+         {:csv-col-name "QABName (code)"
+          :col-name     :qab-name-code
+          :col-label    "QAB name (code)"}
+         {:csv-col-name "QABName (name)"
+          :col-name     :qab-name-name
+          :col-label    "QAB name"}
+         {:csv-col-name "EstablishmentAccredited (code)"
+          :col-name     :establishment-accredited-code
+          :col-label    "Establishment accredited (code)"}
+         {:csv-col-name "EstablishmentAccredited (name)"
+          :col-name     :establishment-accredited-name
+          :col-label    "Establishment accredited"}
+         {:csv-col-name "QABReport"
+          :col-name     :qab-report
+          :col-label    "QAB report"
+          :parser-fn    :string}
+         {:csv-col-name "CHNumber"
+          :col-name     :ch-number
+          :col-label    "CH number"
+          :parser-fn    :string}
+         {:csv-col-name "MSOA (code)"
+          :col-name     :msoa-code
+          :col-label    "MSOA (code)"}
+         {:csv-col-name "LSOA (code)"
+          :col-name     :lsoa-code
+          :col-label    "LSOA (code)"}
+         {:csv-col-name "FSM"
+          :col-name     :fsm
+          :col-label    "FSM"}
+         {:csv-col-name "AccreditationExpiryDate"
+          :col-name     :accreditation-expiry-date
+          :col-label    "Accreditation expiry date"}]
+      $
+    ;; Add CSV file column numbers (for ordering)
+    (map-indexed (fn [idx m] (assoc m :csv-col-num (inc idx))) $)
+    ;; Extract into a map with `:csv-col-name`s as keys
+    (reduce (fn [m v] (assoc m (:csv-col-name v) v)) {} $)
+    ;; Order the map
+    (into (sorted-map-by (partial compare-mapped-keys (update-vals $ :csv-col-num))) $)))
 
 (comment
   ;; Keyword column names created from CSV column lables using:
@@ -472,72 +485,42 @@
                                                    (clojure.string/replace #" +" "-")
                                                    (clojure.string/lower-case)
                                                    keyword))]
-    (into (sorted-map-by (partial compare-mapped-keys csv-col-name->order)) 
-          (map (fn [s] [s (csv-col-name->keyword-col-name s)]))
-          csv-col-names))
+    (map csv-col-name->keyword-col-name
+         (keys edubaseall-csv-columns)))
 
   )
 
-(def col-name->order
-  (let [m (update-keys csv-col-name->order csv-col-name->col-name)]
-    (into (sorted-map-by (partial compare-mapped-keys m)) m)))
-
-(def col-names
-  (apply sorted-set-by
-         (partial compare-mapped-keys col-name->order)
-         (keys col-name->order)))
-
-(def col-name->csv-col-name
-  (into (sorted-map-by (partial compare-mapped-keys col-name->order)) 
-        (set/map-invert csv-col-name->col-name)))
-
-(def col-name->label
-  "Map column name to label."
-  (into (sorted-map-by (partial compare-mapped-keys col-name->order))
-        (update-keys csv-col-name->label csv-col-name->col-name)))
+(def edubaseall-columns
+  "Map (ordered) edubaseall dataset column names to (maps of) metadata."
+  (as-> edubaseall-csv-columns $
+    (update-keys $ (update-vals $ :col-name))
+    (into (sorted-map-by (partial compare-mapped-keys (update-vals $ :csv-col-num))) $)))
 
 
 
 ;;; # Read establishment data
-(def csv-parser-fn
-  "parser-fn for ds/->dataset read of edubasealldata.csv with CSV column names."
-  (let [parse-date (fn [s] (java.time.LocalDate/parse s (java.time.format.DateTimeFormatter/ofPattern "dd-MM-uuuu")))]
-    (into (sorted-map-by (partial compare-mapped-keys csv-col-name->order))
-          {"URN"                         #_:urn                           :string
-           "LA (code)"                   #_:la-code                       :string
-           "EstablishmentNumber"         #_:establishment-number          :string
-           "OpenDate"                    #_:open-date                     [:packed-local-date parse-date]
-           "CloseDate"                   #_:close-date                    [:packed-local-date parse-date]
-           "CensusDate"                  #_:census-date                   [:packed-local-date parse-date]
-           "UKPRN"                       #_:ukprn                         :string
-           "FEHEIdentifier"              #_:fehe-identifier               :string
-           "OfstedLastInsp"              #_:ofsted-last-insp              [:packed-local-date parse-date]
-           "LastChangedDate"             #_:last-changed-date             [:packed-local-date parse-date]
-           "TelephoneNum"                #_:telephone-num                 :string
-           "DateOfLastInspectionVisit"   #_:date-of-last-inspection-visit [:packed-local-date parse-date]
-           "NextInspectionVisit"         #_:next-inspection-visit         [:packed-local-date parse-date]
-           "PreviousLA (code)"           #_:previous-la-code              :string
-           "PreviousEstablishmentNumber" #_:previous-establishment-number :string
-           "UPRN"                        #_:uprn                          :string
-           "QABReport"                   #_:qab-report                    :string
-           "CHNumber"                    #_:ch-number                     :string})))
+(def edubaseall-csv-parser-fn
+  "Default parser-fn for ds/->dataset read of edubaseall with CSV column names."
+  (as-> edubaseall-csv-columns $
+    (filter (comp some? :parser-fn last) $)
+    (into (sorted-map-by (partial compare-mapped-keys (update-vals $ :csv-col-num)))
+          (update-vals $ :parser-fn))))
 
-(def key-fn
-  "Default key-fn to be applied to edubasealldata.csv column names to obtain dataset column names."
-  #(csv-col-name->col-name % %))
+(def edubaseall-csv-key-fn
+  "Default key-fn to be applied to edubaseall CSV file column names to obtain dataset column names."
+  #((update-vals edubaseall-csv-columns :col-name) % %))
 
-(def parser-fn
-  "parser-fn for ds/->dataset read of edubasealldata.csv with `key-fn` applied to CSV column names."
-  (into (sorted-map-by (partial compare-mapped-keys col-name->order))
-        (update-keys csv-parser-fn key-fn)))
+(def edubaseall-parser-fn
+  "Default parser-fn for ds/->dataset read of edubaseall CSV file after `key-fn` applied to CSV column names."
+  (update-keys edubaseall-csv-parser-fn (update-vals edubaseall-csv-columns :col-name)))
 
-(defn ->ds
-  "Read GIAS all establishment data into a dataset.
+(defn edubaseall->ds
+  "Read GIAS edubaseall \"all establishment\" data from CSV file into a dataset.
    Use optional `options` map to specify:
    - CSV file to read: via ::edubaseall-file-path or ::edubaseall-resource-file-name (for files in resource folder).
      [Defaults to ::edubaseall-resource-file-name `default-edubaseall-resource-file-name`.]
    - Additional or over-riding options for `->dataset`."
-  ([] (->ds {}))
+  ([] (edubaseall->ds {}))
   ([{::keys [edubaseall-resource-file-name edubaseall-file-path]
      :or    {edubaseall-resource-file-name default-edubaseall-resource-file-name}
      :as    options}]
@@ -548,8 +531,8 @@
                               :separator    ","
                               :dataset-name (or edubaseall-file-path edubaseall-resource-file-name)
                               :header-row?  true
-                              :key-fn       key-fn
-                              :parser-fn    parser-fn}
+                              :key-fn       edubaseall-csv-key-fn
+                              :parser-fn    edubaseall-parser-fn}
                              options)))))
 
 (comment
@@ -563,13 +546,14 @@
         (tc/map-columns :col-label    [:col-name] col-name->label)
         (tc/reorder-columns [:col-name :csv-col-name :col-label])))
 
-  (-> (->ds
+  (-> (edubaseall->ds
        #_{::edubaseall-file-path "/tmp/edubasealldata20230421.csv"}
        #_{::edubaseall-resource-file-name "edubasealldata20230421.csv"}
        #_{::edubaseall-resource-file-name "edubasealldata20230817.csv"}
        #_{::edubaseall-resource-file-name "edubasealldata20230918.csv"}
        )
-      (csv-ds-column-info col-name->csv-col-name col-name->label)
+      (csv-ds-column-info (update-vals edubaseall-columns :csv-col-name)
+                          (update-vals edubaseall-columns :col-label))
       (vary-meta assoc :print-index-range 1000))
 
   ;; => edubasealldata20230918.csv: descriptive-stats [140 8]:
@@ -721,9 +705,9 @@
 
 (comment
   ;; Write distinct establishment types to data file
-  (-> (->ds {:column-allowlist (map col-name->csv-col-name [:type-of-establishment-code    :type-of-establishment-name
-                                                            :establishment-type-group-code :establishment-type-group-name])
-             :dataset-name     (str (re-find #".+(?=\.csv$)" default-edubaseall-resource-file-name) "-establishment-types" ".csv")})
+  (-> (edubaseall->ds {:column-allowlist (map (update-vals edubaseall-columns :csv-col-name) [:type-of-establishment-code    :type-of-establishment-name
+                                                                                              :establishment-type-group-code :establishment-type-group-name])
+                       :dataset-name     (str (re-find #".+(?=\.csv$)" default-edubaseall-resource-file-name) "-establishment-types" ".csv")})
       (tc/unique-by)
       (tc/order-by [:type-of-establishment-code])
       (as-> $


### PR DESCRIPTION
Enhancements for use for SEND work:
- Parse SEN provision types columns to standard EHCP primary need abbreviations, returning in renamed columns.
- Prepend "edubaseall" to names to open up namespace for more general GIAS related functionality (API change).
- Refactor metadata maps to eliminate duplication.
- Rename `:census-date` (-> `:school-census-date`) to avoid clash with SEN2 and other general `:census-date`s used in SEND processing.
- Rename `:ebd-name` -> `:pru-ebd-name` so context clearer.
- Add functionality to read from edubaseall a dataset tailored for SEND, consisting of selected edubaseall columns and derived columns.